### PR TITLE
Fix for change in Gtk.Window type

### DIFF
--- a/src/System/Tianbar/StrutProperties.hs
+++ b/src/System/Tianbar/StrutProperties.hs
@@ -75,5 +75,5 @@ setStrutProperties window (left, right, top, bottom,
                                  ]
     prop <- atomIntern "_NET_WM_STRUT_PARTIAL" False
     type_ <- atomIntern "CARDINAL" False
-    Just gdkWindow <- Gtk.widgetGetWindow window
+    gdkWindow <- Gtk.widgetGetWindow window
     propertyChange gdkWindow prop type_ 32 PropModeReplace data_


### PR DESCRIPTION
The original one doesn't compile for me using stack on `lts-6.7`. Perhaps some tests had a weird set of versions? (I don't have cabal-install so cannot confirm whether the original one compiles with cabal or not).

After this fix, it seems to compile.
